### PR TITLE
ci: Update Node.js versions in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Update the Node.js versions tested in CI to better align with current Node.js releases and our package requirements.

## Changes

- ❌ Remove Node.js 18.x - This is below our minimum requirement of `>=20.0.0` specified in package.json
- ✅ Add Node.js 24.x - Test against the latest Node.js version
- ✅ Keep Node.js 20.x (LTS) and 22.x for comprehensive coverage

This ensures we're testing against supported versions that meet our minimum requirements while also validating compatibility with the latest Node.js release.