### PR TITLE
fix: Update labeler workflow to avoid permission errors

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,15 +7,18 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   label:
     name: Label Pull Request
     runs-on: ubuntu-latest
+    # Only run on PRs from the same repository (not forks)
+    if: github.event.pull_request.head.repo.full_name == github.repository
     
     steps:
       - name: Label PR
         uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: true
+          sync-labels: false


### PR DESCRIPTION
## Summary

Fix the PR labeler workflow that's causing CI to show as failed on all PRs due to permission errors.

## Problem

The labeler workflow was failing with:
```
HttpError: You do not have permission to create labels on this repository
```

This was causing all PRs to show a red CI status even when all tests were passing.

## Solution

- Set `sync-labels: false` to prevent the action from trying to create new labels
- Only run the labeler on PRs from the same repository (not forks) to avoid permission issues
- Add `issues: write` permission for better label handling

## Result

The labeler will now:
- ✅ Still label PRs based on changed files
- ✅ Not attempt to create new labels (avoiding permission errors)
- ✅ Skip running on fork PRs where it would fail anyway
- ✅ Allow CI to show green when all important checks pass