### PR TITLE
fix: Remove explicit pnpm version from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
       
       - name: Install pnpm
         uses: pnpm/action-setup@v3
-        with:
-          version: 10.11.0
       
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -60,8 +58,6 @@ jobs:
       
       - name: Install pnpm
         uses: pnpm/action-setup@v3
-        with:
-          version: 10.11.0
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -85,8 +81,6 @@ jobs:
       
       - name: Install pnpm
         uses: pnpm/action-setup@v3
-        with:
-          version: 10.11.0
       
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
       
       - name: Install pnpm
         uses: pnpm/action-setup@v3
-        with:
-          version: 10.11.0
       
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,8 +23,6 @@ jobs:
       
       - name: Install pnpm
         uses: pnpm/action-setup@v3
-        with:
-          version: 10.11.0
       
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Remove the explicit version specification from pnpm/action-setup in all workflows to allow it to use the packageManager field from package.json. This fixes the version conflict that was preventing Dependabot PRs from passing CI when updating to pnpm/action-setup@v4.

## Changes

- Remove `version: 10.11.0` from all pnpm/action-setup steps in:
  - `.github/workflows/ci.yml`
  - `.github/workflows/security.yml`
  - `.github/workflows/release.yml`

## Why this is needed

When Dependabot tries to update pnpm/action-setup from v3 to v4, it fails with an error:
```
Error: Multiple versions of pnpm specified:
  - version 10.11.0 in the GitHub Action config with the key "version"
  - version pnpm@10.11.0+sha512... in the package.json with the key "packageManager"
```

The pnpm/action-setup@v4 action is stricter about version conflicts and doesn't allow specifying a version when packageManager is already defined in package.json.

## Impact

- The workflows will continue using pnpm@10.11.0 as specified in the packageManager field
- This will allow Dependabot PRs to pass CI checks
- Future pnpm version updates only need to be made in package.json