### PR TITLE
fix: Use pnpm audit instead of npm audit in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,10 +34,10 @@ jobs:
         run: pnpm audit --audit-level=moderate
         continue-on-error: true
       
-      - name: Run npm audit for production dependencies
+      - name: Run pnpm audit for production dependencies
         run: |
           cd library
-          npm audit --production --audit-level=moderate
+          pnpm audit --prod --audit-level=moderate
         continue-on-error: true
 
   codeql:


### PR DESCRIPTION
## Summary

Fix the dependency audit check in the security workflow to use `pnpm audit` instead of `npm audit`. This was causing Dependabot PRs to fail.

## Problem

The security workflow was running:
```bash
npm audit --production --audit-level=moderate
```

But this fails with:
```
npm error code ENOLOCK
npm error audit This command requires an existing lockfile.
npm error audit Try creating one first with: npm i --package-lock-only
```

Because we're using pnpm (with pnpm-lock.yaml) not npm (with package-lock.json).

## Solution

- Change `npm audit --production` to `pnpm audit --prod`
- This allows the audit to work correctly with pnpm's lockfile

## Impact

Once this is merged, the Dependabot PRs for dependency updates should pass the dependency audit check.