### PR TITLE
chore: Release v0.1.2

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/auth-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Civic Auth integration for MCP servers",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Release v0.1.2

Minor update to include README badges on npm package page.

### Changes

- 🏷️ **Badges**: Added CI, npm version, license, and coverage badges to library README
- 🔗 **Homepage**: Updated package.json homepage to civic.com

These changes will be visible on https://www.npmjs.com/package/@civic/auth-mcp

### Release Process

After merging:
```bash
git tag v0.1.2
git push origin v0.1.2
```