### PR TITLE
fix: allow onLogin callback to return null

### DIFF
--- a/library/src/types.ts
+++ b/library/src/types.ts
@@ -33,7 +33,7 @@ export interface CivicAuthOptions<TRequest extends IncomingMessage = IncomingMes
    * @param request Optional request object that may contain headers or other data
    * @returns Enriched auth info with custom data
    */
-  onLogin?: <T extends ExtendedAuthInfo>(authInfo: ExtendedAuthInfo | null, request?: TRequest) => Promise<T>;
+  onLogin?: <T extends ExtendedAuthInfo>(authInfo: ExtendedAuthInfo | null, request?: TRequest) => Promise<T | null>;
 }
 
 export interface OIDCWellKnownConfiguration {


### PR DESCRIPTION
## Summary
- Allow onLogin callback to return null to reject authentication

## Changes
- Update onLogin return type to include null: \
- This enables authentication flows where the onLogin callback can reject authentication by returning null instead of throwing an error

## Use case
This is useful when you want to conditionally reject authentication based on custom logic without throwing exceptions.