### PR TITLE
feat: add configurable MCP route protection

### DIFF
--- a/examples/client/cli/.env.example
+++ b/examples/client/cli/.env.example
@@ -1,2 +1,4 @@
 # OAuth Client ID for the application
 OAUTH_CLIENT_ID=your-client-id
+# Defaults to http://localhost:33007/mcp
+MCP_SERVER_URL=

--- a/examples/client/cli/src/index.ts
+++ b/examples/client/cli/src/index.ts
@@ -4,6 +4,8 @@ import * as dotenv from "dotenv";
 // Load environment variables
 dotenv.config();
 
+const MCP_SERVER_URL = process.env.MCP_SERVER_URL ?? "http://localhost:33007/mcp";
+
 async function main() {
   // Check for required environment variables
   if (!process.env.OAUTH_CLIENT_ID) {
@@ -17,7 +19,7 @@ async function main() {
   });
 
   // Create the transport with auth provider
-  const serverUrl = new URL("http://localhost:33007/mcp");
+  const serverUrl = new URL(MCP_SERVER_URL);
   const transport = new RestartableStreamableHTTPClientTransport(serverUrl, { authProvider });
 
   // Create and connect client with built-in auth handling

--- a/examples/server/whoami/src/index.ts
+++ b/examples/server/whoami/src/index.ts
@@ -1,7 +1,7 @@
+import { auth } from "@civic/auth-mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import express from "express";
-import {auth} from "@civic/auth-mcp";
-import {StreamableHTTPServerTransport} from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import {McpServer} from "@modelcontextprotocol/sdk/server/mcp.js";
 
 const PORT = process.env.PORT ? Number.parseInt(process.env.PORT) : 33007;
 
@@ -13,54 +13,49 @@ app.use(await auth());
 
 // Create your MCP server
 async function getServer() {
-    const server = new McpServer({
-        name: "whoami-mcp-server",
-        version: "1.0.0",
-    });
+  const server = new McpServer({
+    name: "whoami-mcp-server",
+    version: "1.0.0",
+  });
 
-    // Register your tools
-    server.tool(
-        "whoami",
-        "Get information about the current user",
-        {},
-        async (_, extra) => {
-            // Access the authenticated user's information
-            const user = extra.authInfo?.extra?.sub;
-            return {
-                content: [
-                    {
-                        type: "text",
-                        text: `Hello ${user}!`,
-                    },
-                ],
-            };
-        }
-    );
+  // Register your tools
+  server.tool("whoami", "Get information about the current user", {}, async (_, extra) => {
+    // Access the authenticated user's information
+    const user = extra.authInfo?.extra?.sub;
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Hello ${user}!`,
+        },
+      ],
+    };
+  });
 
-    // Set up the transport layer
-    // In production you may need session management
-    const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-    });
+  // Set up the transport layer
+  // In production you may need session management
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
 
-    await server.connect(transport);
+  await server.connect(transport);
 
-    return { transport, server };
+  return { transport, server };
 }
 
 // Set up MCP endpoint
 app.post("/mcp", async (req, res) => {
-    const { transport, server } = await getServer();
-    await transport.handleRequest(req, res, req.body);
-    res.on('close', () => {
-        transport.close();
-        server.close()
-    })
+  const { transport, server } = await getServer();
+  await transport.handleRequest(req, res, req.body);
+  res.on("close", () => {
+    transport.close();
+    server.close();
+  });
 });
 
 // Start the Express server
 app.listen(PORT, () => {
-    console.log(`MCP server with Civic Auth running at http://localhost:${PORT}`);
-    console.log(`OAuth metadata available at http://localhost:${PORT}/.well-known/oauth-protected-resource`);
-    console.log("\nMCP clients will authenticate directly with Civic Auth!");
+  console.log(`MCP server with Civic Auth running at http://localhost:${PORT}`);
+  console.log(`OAuth metadata available at http://localhost:${PORT}/.well-known/oauth-protected-resource`);
+  console.log("\nMCP clients will authenticate directly with Civic Auth!");
 });

--- a/library/README.md
+++ b/library/README.md
@@ -126,7 +126,7 @@ app.use(await auth({
   // Enrich auth info with custom data from your database
   onLogin: async (authInfo, request) => {
     // Look up user data based on the JWT subject claim
-    const userData = await db.users.findOne({ sub: authInfo.extra.sub });
+    const userData = await db.users.findOne({ sub: authInfo?.extra?.sub });
     // Return enriched auth info
     return {
       ...authInfo,
@@ -149,7 +149,7 @@ const mcpServerAuth = await McpServerAuth.init();
 // Or with custom data enrichment
 const mcpServerAuth = await McpServerAuth.init({
   onLogin: async (authInfo, request) => {
-    const userData = await db.users.findOne({ sub: authInfo.extra.sub });
+    const userData = await db.users.findOne({ sub: authInfo?.extra?.sub });
     return {
       ...authInfo,
       extra: { ...authInfo.extra, ...userData }

--- a/library/README.md
+++ b/library/README.md
@@ -122,6 +122,9 @@ app.use(await auth({
   // Or specify additional options
   issuerUrl: 'https://my-mcp-server.com',
   scopesSupported: ['openid', 'profile', 'email', 'custom:scope'],
+  
+  // Protect a different route (defaults to '/mcp')
+  mcpRoute: '/api',
     
   // Enrich auth info with custom data from your database
   onLogin: async (authInfo, request) => {

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/auth-mcp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Civic Auth integration for MCP servers",
   "keywords": ["mcp", "model-context-protocol", "civic", "auth", "authentication", "oauth", "civic-auth"],
   "homepage": "https://civic.com",

--- a/library/src/client/CLIClient.test.ts
+++ b/library/src/client/CLIClient.test.ts
@@ -100,29 +100,5 @@ describe("CLIClient", () => {
       // Restore original
       Client.prototype.connect = originalConnect;
     });
-
-    it("should log appropriate messages during auth flow", async () => {
-      const consoleSpy = vi.spyOn(console, "log");
-
-      // Set up to simulate auth flow
-      let callCount = 0;
-
-      // Mock the parent class connect method
-      vi.spyOn(Client.prototype, "connect").mockImplementation(async () => {
-        callCount++;
-        if (callCount === 1) {
-          throw new Error("Unauthorized");
-        }
-        // Second call succeeds
-      });
-
-      await client.connect(mockTransport);
-
-      expect(consoleSpy).toHaveBeenCalledWith("Error connecting to MCP server:", expect.any(Error));
-      expect(consoleSpy).toHaveBeenCalledWith("Authorization required, waiting for user to complete OAuth flow...");
-      expect(consoleSpy).toHaveBeenCalledWith("Authorization completed.");
-
-      consoleSpy.mockRestore();
-    });
   });
 });

--- a/library/src/client/CLIClient.ts
+++ b/library/src/client/CLIClient.ts
@@ -15,7 +15,6 @@ export class CLIClient extends Client {
     try {
       await super.connect(transport);
     } catch (error: unknown) {
-      console.log("Error connecting to MCP server:", error);
       // Check if this is an authorization error
       if (error instanceof Error) {
         if (error.message === "Unauthorized") {

--- a/library/src/constants.ts
+++ b/library/src/constants.ts
@@ -9,3 +9,6 @@ export const DEFAULT_SCOPE = "openid profile email";
  * Default callback port for CLI authentication flow
  */
 export const DEFAULT_CALLBACK_PORT = 8080;
+
+// Default mcpRoute to '/mcp' if not specified
+export const DEFAULT_MCP_ROUTE = "/mcp";

--- a/library/src/types.ts
+++ b/library/src/types.ts
@@ -30,6 +30,12 @@ export interface CivicAuthOptions<
   basePath?: string;
 
   /**
+   * The MCP route to protect with authentication
+   * Defaults to '/mcp'
+   */
+  mcpRoute?: string;
+
+  /**
    * Optional callback to enrich the auth info with custom data
    * Called after successful token verification
    * @param authInfo The verified auth info from the token. Null if no token was provided.


### PR DESCRIPTION
## Summary
- Added `mcpRoute` option to configure which routes are protected by authentication (defaults to `/mcp`)
- This allows users to protect different paths, not just the default `/mcp` route

## Changes
- Added `mcpRoute` option to `CivicAuthOptions` interface
- Updated middleware to only protect routes starting with the configured `mcpRoute`
- Added `DEFAULT_MCP_ROUTE` constant
- Updated tests to verify the new behavior
- Added documentation for the new option in README

## Test plan
- [x] All existing tests pass
- [x] Added test to verify non-MCP routes are not protected
- [x] Added test for custom `mcpRoute` configuration
- [x] Build and lint pass