### PR TITLE
fix: handle JWT verification errors properly with 401 response

### DIFF
--- a/library/src/client/providers/CLIAuthProvider.test.ts
+++ b/library/src/client/providers/CLIAuthProvider.test.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import http from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SCOPES } from "../../constants.js";
 import { CLIAuthProvider } from "./CLIAuthProvider.js";
 
 // Mock node modules
@@ -34,7 +35,7 @@ describe("CLIAuthProvider", () => {
     vi.clearAllMocks();
     provider = new CLIAuthProvider({
       clientId: "test-client-id",
-      scope: "openid profile email",
+      scope: DEFAULT_SCOPES.join(" "),
       callbackPort: 8080,
     });
   });
@@ -65,7 +66,7 @@ describe("CLIAuthProvider", () => {
       expect(metadata).toEqual({
         redirect_uris: ["http://localhost:8080/callback"],
         client_name: "test-client-id",
-        scope: "openid profile email",
+        scope: DEFAULT_SCOPES.join(" "),
       });
     });
 
@@ -75,7 +76,7 @@ describe("CLIAuthProvider", () => {
       });
 
       const metadata = minimalProvider.clientMetadata;
-      expect(metadata.scope).toBe("openid profile email"); // DEFAULT_SCOPE
+      expect(metadata.scope).toBe(DEFAULT_SCOPES.join(" ")); // DEFAULT_SCOPES
       expect(metadata.redirect_uris).toEqual(["http://localhost:8080/callback"]); // DEFAULT_CALLBACK_PORT
     });
   });

--- a/library/src/client/providers/CLIAuthProvider.ts
+++ b/library/src/client/providers/CLIAuthProvider.ts
@@ -7,7 +7,7 @@ import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js
 import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { OAuthClientInformation, OAuthClientMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
 import escapeHtml from "escape-html";
-import { DEFAULT_CALLBACK_PORT, DEFAULT_SCOPE } from "../../constants.js";
+import { DEFAULT_CALLBACK_PORT, DEFAULT_SCOPES } from "../../constants.js";
 import { CivicAuthProvider, type CivicAuthProviderOptions } from "./CivicAuthProvider.js";
 
 export interface CLIAuthProviderOptions extends CivicAuthProviderOptions {
@@ -38,13 +38,13 @@ export class CLIAuthProvider extends CivicAuthProvider {
   constructor(options: CLIAuthProviderOptions) {
     super(options);
     this.clientId = options.clientId;
-    this.scope = options.scope || DEFAULT_SCOPE;
-    this.callbackPort = options.callbackPort || DEFAULT_CALLBACK_PORT;
+    this.scope = options.scope ?? DEFAULT_SCOPES.join(" ");
+    this.callbackPort = options.callbackPort ?? DEFAULT_CALLBACK_PORT;
     this.successHtml =
-      options.successHtml ||
+      options.successHtml ??
       '<html lang="en"><body><h1>Authorization Successful</h1><p>You can now close this window.</p></body></html>';
     this.errorHtml =
-      options.errorHtml || '<html lang="en"><body><h1>Authorization Failed</h1><p>{{error}}</p></body></html>';
+      options.errorHtml ?? '<html lang="en"><body><h1>Authorization Failed</h1><p>{{error}}</p></body></html>';
   }
 
   clientInformation(): OAuthClientInformation | Promise<OAuthClientInformation | undefined> | undefined {

--- a/library/src/constants.ts
+++ b/library/src/constants.ts
@@ -3,7 +3,7 @@ export const DEFAULT_WELLKNOWN_URL = "https://auth.civic.com/oauth/.well-known/o
 /**
  * Default scope for OAuth authentication
  */
-export const DEFAULT_SCOPE = "openid profile email";
+export const DEFAULT_SCOPES = ["openid", "profile", "email", "offline-access"];
 
 /**
  * Default callback port for CLI authentication flow

--- a/library/src/types.ts
+++ b/library/src/types.ts
@@ -67,3 +67,21 @@ export interface ExtendedAuthInfo extends AuthInfo {
     picture?: string;
   };
 }
+
+/**
+ * Custom error class for all authentication errors
+ */
+export class AuthenticationError extends Error {}
+
+/**
+ * Custom error class for JWT verification failures
+ */
+export class JWTVerificationError extends AuthenticationError {
+  constructor(
+    message: string,
+    public originalError?: Error
+  ) {
+    super(message);
+    this.name = "JWTVerificationError";
+  }
+}


### PR DESCRIPTION
## Summary
- Add custom error classes (AuthenticationError, JWTVerificationError) for better error handling
- Wrap JWT verification errors to ensure proper 401 responses instead of generic 500 errors
- Fix constants export and improve test coverage for error scenarios

## Changes
- Added `AuthenticationError` and `JWTVerificationError` custom error classes in types.ts
- Modified JWT verification in `McpServerAuth` to catch and wrap jose errors
- Updated error handling in index.ts to return 401 for authentication errors
- Fixed DEFAULT_SCOPES constant export issue
- Enhanced tests to cover JWT verification error scenarios