### PR TITLE
chore: bump version to 0.1.13

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/auth-mcp",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Civic Auth integration for MCP servers",
   "keywords": ["mcp", "model-context-protocol", "civic", "auth", "authentication", "oauth", "civic-auth"],
   "homepage": "https://civic.com",


### PR DESCRIPTION
Bump library version to 0.1.13 following the JWT error handling fix.