### PR TITLE
fix: correct offline_access scope format

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/auth-mcp",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Civic Auth integration for MCP servers",
   "keywords": ["mcp", "model-context-protocol", "civic", "auth", "authentication", "oauth", "civic-auth"],
   "homepage": "https://civic.com",

--- a/library/src/constants.ts
+++ b/library/src/constants.ts
@@ -3,7 +3,7 @@ export const DEFAULT_WELLKNOWN_URL = "https://auth.civic.com/oauth/.well-known/o
 /**
  * Default scope for OAuth authentication
  */
-export const DEFAULT_SCOPES = ["openid", "profile", "email", "offline-access"];
+export const DEFAULT_SCOPES = ["openid", "profile", "email", "offline_access"];
 
 /**
  * Default callback port for CLI authentication flow

--- a/library/src/index.test.ts
+++ b/library/src/index.test.ts
@@ -16,7 +16,7 @@ vi.mock("./McpServerAuth.js", () => ({
       mockGetProtectedResourceMetadata = vi.fn((issuerUrl) => ({
         resource: issuerUrl,
         authorization_servers: ["https://auth.civic.com"],
-        scopes_supported: ["openid", "profile", "email", "offline-access"],
+        scopes_supported: ["openid", "profile", "email", "offline_access"],
         bearer_methods_supported: ["header"],
         resource_documentation: "https://docs.civic.com",
         resource_policy_uri: "https://www.civic.com/privacy-policy",


### PR DESCRIPTION
## Summary
Fix incorrect OAuth scope format by changing `offline-access` to `offline_access` (underscore instead of hyphen).

## Changes
- Update DEFAULT_SCOPES constant to use correct `offline_access` format
- Update test to match the corrected scope format
- Bump version to 0.1.14

## Impact
This fix ensures proper OAuth scope formatting for offline access tokens.