### PR TITLE
CLIAuthProvider fixes and improvements

### DIFF
--- a/library/src/client/CLIClient.ts
+++ b/library/src/client/CLIClient.ts
@@ -17,21 +17,18 @@ export class CLIClient extends Client {
     } catch (error: unknown) {
       // Check if this is an authorization error
       if (error instanceof Error) {
+        // This error.message is ONLY returned if auth() in @modelcontextprotocol/sdk/client/auth.js
+        // returns "REDIRECT", therefore we waitForAuthorizationCode() and connect again.
         if (error.message === "Unauthorized") {
           console.log("Authorization required, waiting for user to complete OAuth flow...");
           const authProvider = transport.authProvider;
 
-          // only wait if the tokens have not been set already
-          const tokens = await authProvider.tokens();
-          if (!tokens) {
-            // Wait for the OAuth flow to complete
-            await authProvider.waitForAuthorizationCode();
-            console.log("Authorization completed.");
+          // Wait for the OAuth flow to complete
+          await authProvider.waitForAuthorizationCode();
+          console.log("Authorization completed.");
 
-            // Retry the connection - the auth provider now has tokens
-            return await super.connect(transport);
-          }
-          console.log("Authorization already completed, but still unauthorized.");
+          // Retry the connection - the auth provider now has tokens
+          return await super.connect(transport);
         }
       }
 

--- a/library/src/client/providers/CLIAuthProvider.test.ts
+++ b/library/src/client/providers/CLIAuthProvider.test.ts
@@ -240,12 +240,19 @@ describe("CLIAuthProvider", () => {
       expect(mockServerWithConflict.listen).toHaveBeenCalledWith(0, "localhost");
       expect(mockServerWithConflict.listen).toHaveBeenCalledTimes(2);
 
-      // Verify the actual callback port was updated
+      // Verify that redirectUrl and clientMetadata still use the configured port
       const redirectUrl = providerWithFallback.redirectUrl;
-      expect(redirectUrl.toString()).toBe("http://localhost:3000/callback");
+      expect(redirectUrl.toString()).toBe("http://localhost:8080/callback");
 
       const metadata = providerWithFallback.clientMetadata;
-      expect(metadata.redirect_uris).toEqual(["http://localhost:3000/callback"]);
+      expect(metadata.redirect_uris).toEqual(["http://localhost:8080/callback"]);
+
+      // The authorization URL should have been modified with the actual port
+      expect(execFile).toHaveBeenCalledWith(
+        "xdg-open",
+        [expect.stringContaining("redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback")],
+        expect.any(Function)
+      );
     });
 
     it("should throw error when port is in use and fallback is disabled", async () => {


### PR DESCRIPTION
## Summary
- fixed token-refresh usecase, by removing unneeded token check in CLIClient
- fixed dynamic port allocation
- Remove `actualCallbackPort` property and have `startCallbackServer()` return port only when different from configured port
- Add comprehensive server timeout test coverage
- Improve cleanup method to reset all authorization state properly

## Changes
- **Removed**: `actualCallbackPort` property tracking
- **Modified**: `startCallbackServer()` to return `number | undefined` based on port difference
- **Enhanced**: Promise handling with global `authorizationCodeResolve`/`authorizationCodeReject` functions
- **Improved**: `cleanup()` method to clear all state including promise handlers
- **Added**: Server timeout test to verify cleanup behavior
- **Fixed**: Timeout handler to only perform cleanup without rejecting promises

## Test Results
- All 62 tests passing
- Build successful with no TypeScript errors
- Lint clean with no issues
- Added timeout test verifies proper server cleanup

## Breaking Changes
None - all public APIs remain unchanged