### PR TITLE
feat: handle all OAuth protected resource routes with wildcard matching

### DIFF
--- a/library/src/index.ts
+++ b/library/src/index.ts
@@ -48,7 +48,8 @@ export async function auth<TAuthInfo extends ExtendedAuthInfo>(
 
   // Expose OAuth Protected Resource Metadata
   // This tells MCP clients where to authenticate
-  router.get("/.well-known/oauth-protected-resource", (req, res) => {
+  // Handle all routes starting with /.well-known/oauth-protected-resource
+  router.use("/.well-known/oauth-protected-resource", (req, res) => {
     const issuerUrl = options.issuerUrl || `${req.protocol}://${req.get("host")}`;
     const issuerUrlString = typeof issuerUrl === "string" ? issuerUrl : issuerUrl.toString();
     const metadata = mcpServerAuth.getProtectedResourceMetadata(issuerUrlString);


### PR DESCRIPTION
## Summary
- Changed `router.get()` to `router.use()` for the `/.well-known/oauth-protected-resource` endpoint
- This allows the route to handle all subpaths (e.g., `/.well-known/oauth-protected-resource/hub/mcp`)
- All paths starting with `/.well-known/oauth-protected-resource` now return the same OAuth metadata

## Test plan
- [ ] Verify `/.well-known/oauth-protected-resource` still returns metadata
- [ ] Verify `/.well-known/oauth-protected-resource/hub/mcp` returns the same metadata
- [ ] Verify any other subpath under `/.well-known/oauth-protected-resource/*` returns metadata
- [ ] Ensure no regression in existing OAuth functionality
