### PR TITLE
fix: ensure OAuth clients always receive default scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2025-09-08
+
+### Fixed
+- OAuth authorization requests now always include default scopes (openid email profile) when clients don't specify any
+- Prevents authorization errors with OAuth clients that don't request scopes explicitly
+
 ## [0.2.4] - 2025-09-08
 
 ### Added
@@ -53,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Version bump, readme and spec cleanup
 
+[0.2.5]: https://github.com/civicteam/auth-mcp/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/civicteam/auth-mcp/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/civicteam/auth-mcp/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/civicteam/auth-mcp/compare/v0.2.1...v0.2.2

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/auth-mcp",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Civic Auth integration for MCP servers",
   "keywords": [
     "mcp",

--- a/library/src/legacy/OAuthProxyHandler.ts
+++ b/library/src/legacy/OAuthProxyHandler.ts
@@ -12,6 +12,9 @@ import type {
   TokenRequest,
 } from "./types.js";
 
+// Handling clients that do not request scopes
+const DEFAULT_SCOPES = "openid email profile"
+
 /**
  * Handles OAuth endpoint proxying for legacy mode
  */
@@ -43,7 +46,7 @@ export class OAuthProxyHandler<TAuthInfo extends ExtendedAuthInfo, TRequest exte
         client_id: params.get("client_id") || "",
         redirect_uri: params.get("redirect_uri") || "",
         state: params.get("state") || undefined,
-        scope: params.get("scope") || undefined,
+        scope: params.get("scope") || DEFAULT_SCOPES, // Do not permit missing scopes.
         code_challenge: params.get("code_challenge") || undefined,
         code_challenge_method: params.get("code_challenge_method") || undefined,
       };
@@ -278,8 +281,8 @@ export class OAuthProxyHandler<TAuthInfo extends ExtendedAuthInfo, TRequest exte
       }
 
       // Replace the scope with the fixed set of scopes to avoid registration errors
-      console.log(`Replacing requested scopes "${bodyObj.scope}" with "openid email profile"`);
-      bodyObj.scope = "openid email profile";
+      console.log(`Replacing requested scopes "${bodyObj.scope}" with "${DEFAULT_SCOPES}"`);
+      bodyObj.scope = DEFAULT_SCOPES;
 
       // Forward the registration request to the actual auth server
       const registrationResponse = await fetch(this.oidcConfig.registration_endpoint, {


### PR DESCRIPTION
## Summary
- Adds default scopes (openid email profile) when OAuth clients don't specify any
- Prevents authorization errors with clients that don't request scopes explicitly
- Consolidates default scope definition into a single constant

## Changes
- Modified `OAuthProxyHandler` to apply default scopes when none are provided
- Ensures consistent behavior across authorization and registration flows

## Test plan
- [x] All existing tests pass
- [ ] Verify OAuth clients without explicit scopes work correctly
- [ ] Confirm clients with explicit scopes still use their requested scopes
- [ ] Test both authorization and registration flows