### PR TITLE
fix: add WWW-Authenticate header to 401 responses per RFC9728

### DIFF
--- a/library/src/index.test.ts
+++ b/library/src/index.test.ts
@@ -129,6 +129,11 @@ describe("auth middleware", () => {
         error: "authentication_error",
         error_description: "Authentication failed",
       });
+
+      // Per RFC9728 Section 5.1, WWW-Authenticate header must be included
+      expect(response.headers["www-authenticate"]).toMatch(
+        /^Bearer resource_metadata="http:\/\/127\.0\.0\.1:\d+\/\.well-known\/oauth-protected-resource"$/
+      );
     });
 
     it("should reject requests with invalid authorization header", async () => {
@@ -140,6 +145,11 @@ describe("auth middleware", () => {
         error: "authentication_error",
         error_description: "Authentication failed",
       });
+
+      // Per RFC9728 Section 5.1, WWW-Authenticate header must be included
+      expect(response.headers["www-authenticate"]).toMatch(
+        /^Bearer resource_metadata="http:\/\/127\.0\.0\.1:\d+\/\.well-known\/oauth-protected-resource"$/
+      );
     });
 
     it("should reject requests with invalid tokens", async () => {
@@ -152,6 +162,11 @@ describe("auth middleware", () => {
         error: "authentication_error",
         error_description: "Token validation failed",
       });
+
+      // Per RFC9728 Section 5.1, WWW-Authenticate header must be included
+      expect(response.headers["www-authenticate"]).toMatch(
+        /^Bearer resource_metadata="http:\/\/127\.0\.0\.1:\d+\/\.well-known\/oauth-protected-resource"$/
+      );
     });
 
     it("should skip auth for metadata endpoint", async () => {
@@ -207,6 +222,11 @@ describe("auth middleware", () => {
         error: "authentication_error",
         error_description: '"exp" claim timestamp check failed',
       });
+
+      // Per RFC9728 Section 5.1, WWW-Authenticate header must be included
+      expect(response.headers["www-authenticate"]).toMatch(
+        /^Bearer resource_metadata="http:\/\/127\.0\.0\.1:\d+\/\.well-known\/oauth-protected-resource"$/
+      );
     });
 
     it("should return 500 for unknown errors", async () => {

--- a/library/src/index.ts
+++ b/library/src/index.ts
@@ -93,6 +93,12 @@ export async function auth<TAuthInfo extends ExtendedAuthInfo>(
     } catch (error) {
       if (error instanceof AuthenticationError) {
         // authentication errors e.g. jwt verification errors (expired, invalid signature, etc.) should return 401
+        // Per RFC9728 Section 5.1, include WWW-Authenticate header with resource metadata URL
+        const protocol = options.forceHttps ? "https" : req.protocol;
+        const host = req.get("host");
+        const metadataUrl = `${protocol}://${host}/.well-known/oauth-protected-resource`;
+
+        res.setHeader("WWW-Authenticate", `Bearer resource_metadata="${metadataUrl}"`);
         res.status(401).json({
           error: "authentication_error",
           error_description: error.message,

--- a/library/src/legacy/OAuthProxyHandler.ts
+++ b/library/src/legacy/OAuthProxyHandler.ts
@@ -13,7 +13,7 @@ import type {
 } from "./types.js";
 
 // Handling clients that do not request scopes
-const DEFAULT_SCOPES = "openid email profile"
+const DEFAULT_SCOPES = "openid email profile";
 
 /**
  * Handles OAuth endpoint proxying for legacy mode


### PR DESCRIPTION
## Summary
- Added WWW-Authenticate header with resource_metadata parameter to all 401 Unauthorized responses
- Ensures compliance with RFC9728 Section 5.1 requirements for MCP servers
- Added comprehensive test coverage for the new header in authentication failure scenarios

## Context
Per the MCP specification and RFC9728 Section 5.1, MCP servers MUST use the HTTP header WWW-Authenticate when returning a 401 Unauthorized to indicate the location of the resource server metadata URL.

## Changes
- Modified `/library/src/index.ts` to include WWW-Authenticate header in 401 responses
- Updated tests to verify the header is present with correct format
- Header format: `Bearer resource_metadata="<metadata-url>"`