### PR TITLE
feat: support CIMD (Client ID Metadata Documents) for client registration

### DIFF
--- a/examples/client/cli/src/index.ts
+++ b/examples/client/cli/src/index.ts
@@ -8,13 +8,17 @@ const MCP_SERVER_URL = process.env.MCP_SERVER_URL ?? "http://localhost:33007/mcp
 
 async function main() {
   // Check for required environment variables
-  if (!process.env.OAUTH_CLIENT_ID) {
-    throw new Error("OAUTH_CLIENT_ID environment variable is required");
+  if (!process.env.OAUTH_CLIENT_ID && !process.env.OAUTH_CLIENT_METADATA_URL) {
+    throw new Error("Either OAUTH_CLIENT_ID or OAUTH_CLIENT_METADATA_URL environment variable is required");
   }
 
-  // Create the auth provider
+  // Create the auth provider. A pre-registered client ID takes precedence;
+  // otherwise the hosted Client ID Metadata Document URL is used as the
+  // client_id (CIMD), falling back to Dynamic Client Registration if the
+  // authorization server does not support CIMD.
   const authProvider = new CLIAuthProvider({
     clientId: process.env.OAUTH_CLIENT_ID,
+    clientMetadataUrl: process.env.OAUTH_CLIENT_METADATA_URL,
   });
 
   // Create the transport with auth provider

--- a/library/README.md
+++ b/library/README.md
@@ -224,6 +224,45 @@ const mcpClient = new CLIClient(
 await mcpClient.connect(transport);
 ```
 
+### 🪪 Client ID Metadata Documents (CIMD)
+
+Instead of pre-registering a client ID, your client can identify itself with a
+[Client ID Metadata Document](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00)
+(SEP-991) — a JSON document hosted at an HTTPS URL that doubles as the OAuth `client_id`.
+This is the preferred registration mechanism in the MCP spec since 2025-11-25 and is used by
+Claude, Claude Code, and VS Code.
+
+If your metadata document is already hosted somewhere, pass its URL instead of a client ID:
+
+```typescript
+const authProvider = new CLIAuthProvider({
+  clientMetadataUrl: "https://myagent.example.com/oauth/client-metadata.json",
+});
+```
+
+When the authorization server advertises `client_id_metadata_document_supported`, the URL is
+used directly as the `client_id`; otherwise the flow falls back to Dynamic Client Registration.
+A pre-registered `clientId`, if also provided, always takes precedence.
+
+To host the document itself, build it with `buildClientMetadataDocument` or serve it with the
+Express handler — mounted at the exact path of its public URL:
+
+```typescript
+import { clientMetadataHandler } from "@civic/auth-mcp";
+import { LOOPBACK_REDIRECT_URIS } from "@civic/auth-mcp/client";
+
+app.get(
+  "/oauth/client-metadata.json",
+  clientMetadataHandler({
+    url: "https://myagent.example.com/oauth/client-metadata.json",
+    clientName: "My Agent",
+    // For CLI/native clients use portless loopback URIs (RFC 8252);
+    // for web clients list your hosted callback URLs.
+    redirectUris: LOOPBACK_REDIRECT_URIS,
+  })
+);
+```
+
 ### 💾 Token Persistence
 
 By default, tokens are stored in memory and lost when the process exits. You can configure persistent token storage by implementing the `TokenPersistence` interface.

--- a/library/src/client/clientMetadataDocument.test.ts
+++ b/library/src/client/clientMetadataDocument.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertValidClientMetadataUrl,
+  buildClientMetadataDocument,
+  LOOPBACK_REDIRECT_URIS,
+} from "./clientMetadataDocument.js";
+
+const VALID_URL = "https://app.example.com/oauth/client-metadata.json";
+
+describe("assertValidClientMetadataUrl", () => {
+  it("accepts an HTTPS URL with a path component", () => {
+    expect(() => assertValidClientMetadataUrl(VALID_URL)).not.toThrow();
+  });
+
+  it("rejects a non-URL string", () => {
+    expect(() => assertValidClientMetadataUrl("not a url")).toThrow(/valid URL/);
+  });
+
+  it("rejects http URLs", () => {
+    expect(() => assertValidClientMetadataUrl("http://app.example.com/client.json")).toThrow(/https scheme/);
+  });
+
+  it("rejects URLs without a path component", () => {
+    expect(() => assertValidClientMetadataUrl("https://app.example.com")).toThrow(/path component/);
+    expect(() => assertValidClientMetadataUrl("https://app.example.com/")).toThrow(/path component/);
+  });
+
+  it("rejects URLs with a fragment", () => {
+    expect(() => assertValidClientMetadataUrl(`${VALID_URL}#frag`)).toThrow(/fragment/);
+  });
+
+  it("rejects URLs with embedded credentials", () => {
+    expect(() => assertValidClientMetadataUrl("https://user:pass@app.example.com/client.json")).toThrow(/credentials/);
+  });
+});
+
+describe("buildClientMetadataDocument", () => {
+  it("uses the hosting URL verbatim as client_id", () => {
+    const document = buildClientMetadataDocument({
+      url: VALID_URL,
+      clientName: "Test Client",
+      redirectUris: LOOPBACK_REDIRECT_URIS,
+    });
+
+    expect(document.client_id).toBe(VALID_URL);
+    expect(document.client_name).toBe("Test Client");
+    expect(document.redirect_uris).toEqual(["http://localhost/callback", "http://127.0.0.1/callback"]);
+  });
+
+  it("applies public-client defaults", () => {
+    const document = buildClientMetadataDocument({
+      url: VALID_URL,
+      clientName: "Test Client",
+      redirectUris: LOOPBACK_REDIRECT_URIS,
+    });
+
+    expect(document.grant_types).toEqual(["authorization_code", "refresh_token"]);
+    expect(document.response_types).toEqual(["code"]);
+    expect(document.token_endpoint_auth_method).toBe("none");
+  });
+
+  it("includes optional fields only when provided", () => {
+    const minimal = buildClientMetadataDocument({
+      url: VALID_URL,
+      clientName: "Test Client",
+      redirectUris: LOOPBACK_REDIRECT_URIS,
+    });
+    expect(minimal).not.toHaveProperty("client_uri");
+    expect(minimal).not.toHaveProperty("logo_uri");
+    expect(minimal).not.toHaveProperty("scope");
+
+    const full = buildClientMetadataDocument({
+      url: VALID_URL,
+      clientName: "Test Client",
+      redirectUris: ["https://app.example.com/callback"],
+      clientUri: "https://app.example.com",
+      logoUri: "https://app.example.com/logo.png",
+      scope: "openid profile",
+    });
+    expect(full.client_uri).toBe("https://app.example.com");
+    expect(full.logo_uri).toBe("https://app.example.com/logo.png");
+    expect(full.scope).toBe("openid profile");
+  });
+
+  it("rejects an empty redirect URI list", () => {
+    expect(() => buildClientMetadataDocument({ url: VALID_URL, clientName: "Test Client", redirectUris: [] })).toThrow(
+      /redirect URI/
+    );
+  });
+
+  it("rejects an invalid hosting URL", () => {
+    expect(() =>
+      buildClientMetadataDocument({
+        url: "http://app.example.com/client.json",
+        clientName: "Test Client",
+        redirectUris: LOOPBACK_REDIRECT_URIS,
+      })
+    ).toThrow(/https scheme/);
+  });
+});

--- a/library/src/client/clientMetadataDocument.ts
+++ b/library/src/client/clientMetadataDocument.ts
@@ -1,0 +1,118 @@
+import type { OAuthClientMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
+
+/**
+ * An OAuth Client ID Metadata Document (CIMD) as defined by
+ * draft-ietf-oauth-client-id-metadata-document and adopted by MCP (SEP-991).
+ * The document is hosted at an HTTPS URL which doubles as the OAuth client_id.
+ */
+export type ClientIdMetadataDocument = OAuthClientMetadata & {
+  client_id: string;
+  client_name: string;
+  redirect_uris: string[];
+};
+
+export interface ClientMetadataDocumentOptions {
+  /**
+   * The HTTPS URL at which this document is hosted.
+   * Used verbatim as the OAuth client_id, so it must match the public URL exactly.
+   */
+  url: string;
+
+  /**
+   * Human-readable client name, shown on the authorization server's consent screen.
+   */
+  clientName: string;
+
+  /**
+   * Redirect URIs the authorization server should accept for this client.
+   * For CLI/native clients, use LOOPBACK_REDIRECT_URIS: RFC 8252 requires
+   * authorization servers to accept any port on loopback redirects, so the
+   * URIs are listed without ports.
+   */
+  redirectUris: string[];
+
+  /**
+   * URL of the client's home page, shown on consent screens.
+   */
+  clientUri?: string;
+
+  /**
+   * URL of the client's logo, shown on consent screens.
+   */
+  logoUri?: string;
+
+  /**
+   * Space-separated scopes the client intends to request.
+   */
+  scope?: string;
+
+  /**
+   * OAuth grant types the client uses. Defaults to authorization_code + refresh_token.
+   */
+  grantTypes?: string[];
+
+  /**
+   * OAuth response types the client uses. Defaults to ["code"].
+   */
+  responseTypes?: string[];
+}
+
+/**
+ * Portless loopback redirect URIs for CLI/native clients, matching the path
+ * used by CLIAuthProvider's local callback server. Authorization servers
+ * following RFC 8252 accept these regardless of the port the client binds.
+ */
+export const LOOPBACK_REDIRECT_URIS = ["http://localhost/callback", "http://127.0.0.1/callback"];
+
+/**
+ * Validates that a URL is usable as a CIMD client_id: HTTPS scheme, a non-root
+ * path component, no fragment, and no embedded credentials.
+ * Throws a descriptive error if the URL is invalid.
+ */
+export const assertValidClientMetadataUrl = (value: string): void => {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Client metadata URL must be a valid URL, got: ${value}`);
+  }
+  if (url.protocol !== "https:") {
+    throw new Error(`Client metadata URL must use the https scheme, got: ${value}`);
+  }
+  if (url.pathname === "/") {
+    throw new Error(`Client metadata URL must contain a path component, got: ${value}`);
+  }
+  if (url.hash) {
+    throw new Error(`Client metadata URL must not contain a fragment, got: ${value}`);
+  }
+  if (url.username || url.password) {
+    throw new Error(`Client metadata URL must not contain credentials, got: ${value}`);
+  }
+};
+
+/**
+ * Builds a spec-compliant Client ID Metadata Document. The document's
+ * client_id is derived from the hosting URL, guaranteeing the exact-match
+ * requirement authorization servers validate when fetching the document.
+ *
+ * token_endpoint_auth_method is always "none": CIMD clients are public
+ * clients using PKCE — there is no registration exchange in which an
+ * authorization server could issue a secret.
+ */
+export const buildClientMetadataDocument = (options: ClientMetadataDocumentOptions): ClientIdMetadataDocument => {
+  assertValidClientMetadataUrl(options.url);
+  if (options.redirectUris.length === 0) {
+    throw new Error("Client metadata document requires at least one redirect URI");
+  }
+  return {
+    client_id: options.url,
+    client_name: options.clientName,
+    redirect_uris: options.redirectUris,
+    grant_types: options.grantTypes ?? ["authorization_code", "refresh_token"],
+    response_types: options.responseTypes ?? ["code"],
+    token_endpoint_auth_method: "none",
+    ...(options.clientUri && { client_uri: options.clientUri }),
+    ...(options.logoUri && { logo_uri: options.logoUri }),
+    ...(options.scope && { scope: options.scope }),
+  };
+};

--- a/library/src/client/index.ts
+++ b/library/src/client/index.ts
@@ -4,6 +4,8 @@
 export * from "../constants.js";
 // Re-export CLIClient
 export { CLIClient } from "./CLIClient.js";
+// Re-export CIMD client metadata document helpers
+export * from "./clientMetadataDocument.js";
 export * from "./providers/index.js";
 // Re-export from transport
 export * from "./transport/index.js";

--- a/library/src/client/providers/CLIAuthProvider.test.ts
+++ b/library/src/client/providers/CLIAuthProvider.test.ts
@@ -533,3 +533,50 @@ describe("CLIAuthProvider", () => {
     });
   });
 });
+
+describe("CLIAuthProvider with a Client ID Metadata Document (CIMD)", () => {
+  const CLIENT_METADATA_URL = "https://app.example.com/oauth/client-metadata.json";
+
+  it("requires either a clientId or a clientMetadataUrl", () => {
+    expect(() => new CLIAuthProvider({})).toThrow(/clientId or a clientMetadataUrl/);
+  });
+
+  it("rejects an invalid clientMetadataUrl at construction time", () => {
+    expect(() => new CLIAuthProvider({ clientMetadataUrl: "http://insecure.example.com/client.json" })).toThrow(
+      /https scheme/
+    );
+    expect(() => new CLIAuthProvider({ clientMetadataUrl: "https://app.example.com" })).toThrow(/path component/);
+  });
+
+  it("exposes clientMetadataUrl for the SDK's CIMD flow", () => {
+    const provider = new CLIAuthProvider({ clientMetadataUrl: CLIENT_METADATA_URL });
+    expect(provider.clientMetadataUrl).toBe(CLIENT_METADATA_URL);
+  });
+
+  it("returns no client information until the SDK saves it", () => {
+    const provider = new CLIAuthProvider({ clientMetadataUrl: CLIENT_METADATA_URL });
+    expect(provider.clientInformation()).toBeUndefined();
+  });
+
+  it("returns client information saved by the SDK (CIMD or DCR fallback)", () => {
+    const provider = new CLIAuthProvider({ clientMetadataUrl: CLIENT_METADATA_URL });
+    provider.saveClientInformation({ client_id: CLIENT_METADATA_URL });
+    expect(provider.clientInformation()).toEqual({ client_id: CLIENT_METADATA_URL });
+  });
+
+  it("prefers a pre-registered clientId over the metadata URL", () => {
+    const provider = new CLIAuthProvider({
+      clientId: "pre-registered-id",
+      clientMetadataUrl: CLIENT_METADATA_URL,
+    });
+    expect(provider.clientInformation()).toEqual({ client_id: "pre-registered-id" });
+  });
+
+  it("uses clientName, then clientId, then a default for DCR metadata", () => {
+    const named = new CLIAuthProvider({ clientMetadataUrl: CLIENT_METADATA_URL, clientName: "My Agent" });
+    expect(named.clientMetadata.client_name).toBe("My Agent");
+
+    const unnamed = new CLIAuthProvider({ clientMetadataUrl: CLIENT_METADATA_URL });
+    expect(unnamed.clientMetadata.client_name).toBe("Civic Auth MCP Client");
+  });
+});

--- a/library/src/client/providers/CLIAuthProvider.ts
+++ b/library/src/client/providers/CLIAuthProvider.ts
@@ -6,13 +6,12 @@ import url from "node:url";
 import { promisify } from "node:util";
 import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { OAuthClientInformation, OAuthClientMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { OAuthClientMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
 import escapeHtml from "escape-html";
 import { DEFAULT_CALLBACK_PORT, DEFAULT_SCOPES } from "../../constants.js";
 import { CivicAuthProvider, type CivicAuthProviderOptions } from "./CivicAuthProvider.js";
 
 export interface CLIAuthProviderOptions extends CivicAuthProviderOptions {
-  clientId: string;
   scope?: string;
   callbackPort?: number;
   enablePortFallback?: boolean;
@@ -27,7 +26,6 @@ export interface CLIAuthProviderOptions extends CivicAuthProviderOptions {
  */
 export class CLIAuthProvider extends CivicAuthProvider {
   private storedCodeVerifier: string | undefined;
-  private clientId: string;
   private scope: string;
   private callbackPort: number;
   private enablePortFallback: boolean;
@@ -43,7 +41,9 @@ export class CLIAuthProvider extends CivicAuthProvider {
 
   constructor(options: CLIAuthProviderOptions) {
     super(options);
-    this.clientId = options.clientId;
+    if (!options.clientId && !options.clientMetadataUrl) {
+      throw new Error("CLIAuthProvider requires either a clientId or a clientMetadataUrl");
+    }
     this.scope = options.scope ?? DEFAULT_SCOPES.join(" ");
     this.callbackPort = options.callbackPort ?? DEFAULT_CALLBACK_PORT;
     this.enablePortFallback = options.enablePortFallback ?? true;
@@ -55,23 +55,10 @@ export class CLIAuthProvider extends CivicAuthProvider {
       options.errorHtml ?? '<html lang="en"><body><h1>Authorization Failed</h1><p>{{error}}</p></body></html>';
   }
 
-  clientInformation(): OAuthClientInformation | Promise<OAuthClientInformation | undefined> | undefined {
-    const info: OAuthClientInformation = {
-      client_id: this.clientId,
-    };
-
-    // Include client_secret if provided (for non-PKCE auth servers)
-    if (this.clientSecret) {
-      info.client_secret = this.clientSecret;
-    }
-
-    return info;
-  }
-
   get clientMetadata(): OAuthClientMetadata {
     return {
       redirect_uris: [this.getCallbackUrl(this.callbackPort)],
-      client_name: this.clientId,
+      client_name: this.clientName ?? this.clientId ?? "Civic Auth MCP Client",
       scope: this.scope,
     };
   }

--- a/library/src/client/providers/CivicAuthProvider.ts
+++ b/library/src/client/providers/CivicAuthProvider.ts
@@ -4,9 +4,30 @@ import type {
   OAuthClientMetadata,
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { assertValidClientMetadataUrl } from "../clientMetadataDocument.js";
 import { InMemoryTokenPersistence, type TokenPersistence } from "./persistence/index.js";
 
 export interface CivicAuthProviderOptions {
+  /**
+   * A pre-registered OAuth client ID. Takes precedence over clientMetadataUrl
+   * when both are provided, matching the MCP client registration priority order.
+   */
+  clientId?: string;
+
+  /**
+   * HTTPS URL of a hosted Client ID Metadata Document (CIMD, SEP-991).
+   * When the authorization server advertises client_id_metadata_document_supported,
+   * this URL is used directly as the client_id — no registration required.
+   * Otherwise the flow falls back to Dynamic Client Registration.
+   */
+  clientMetadataUrl?: string;
+
+  /**
+   * Human-readable client name used in Dynamic Client Registration requests.
+   * Defaults to the clientId when one is provided.
+   */
+  clientName?: string;
+
   /**
    * Client secret for OAuth flows that don't support PKCE.
    * Optional - only needed for auth servers that require client authentication.
@@ -24,15 +45,51 @@ export interface CivicAuthProviderOptions {
  * Abstract base class for Civic auth providers
  */
 export abstract class CivicAuthProvider implements OAuthClientProvider {
+  protected clientId?: string;
+  protected clientName?: string;
   protected clientSecret?: string;
   protected tokenPersistence: TokenPersistence;
+  readonly clientMetadataUrl?: string;
+  private savedClientInformation?: OAuthClientInformation;
 
   constructor(options: CivicAuthProviderOptions) {
+    if (options.clientMetadataUrl) {
+      assertValidClientMetadataUrl(options.clientMetadataUrl);
+    }
+    this.clientId = options.clientId;
+    this.clientMetadataUrl = options.clientMetadataUrl;
+    this.clientName = options.clientName;
     this.clientSecret = options.clientSecret;
     this.tokenPersistence = options.tokenPersistence ?? new InMemoryTokenPersistence();
   }
 
-  abstract clientInformation(): OAuthClientInformation | Promise<OAuthClientInformation | undefined> | undefined;
+  /**
+   * Returns the pre-registered client information if a clientId was configured.
+   * Without one, registration is delegated to the SDK, which uses the
+   * clientMetadataUrl as client_id when the authorization server supports
+   * CIMD, or falls back to Dynamic Client Registration. Either result
+   * arrives via saveClientInformation.
+   */
+  clientInformation(): OAuthClientInformation | Promise<OAuthClientInformation | undefined> | undefined {
+    if (!this.clientId) {
+      return this.savedClientInformation;
+    }
+
+    const info: OAuthClientInformation = {
+      client_id: this.clientId,
+    };
+
+    // Include client_secret if provided (for non-PKCE auth servers)
+    if (this.clientSecret) {
+      info.client_secret = this.clientSecret;
+    }
+
+    return info;
+  }
+
+  saveClientInformation(clientInformation: OAuthClientInformation): void {
+    this.savedClientInformation = clientInformation;
+  }
 
   abstract get clientMetadata(): OAuthClientMetadata;
 

--- a/library/src/clientMetadataHandler.test.ts
+++ b/library/src/clientMetadataHandler.test.ts
@@ -1,0 +1,57 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { clientMetadataHandler } from "./clientMetadataHandler.js";
+
+const URL = "https://app.example.com/oauth/client-metadata.json";
+
+const buildApp = (cacheMaxAgeSeconds?: number) => {
+  const app = express();
+  app.get(
+    "/oauth/client-metadata.json",
+    clientMetadataHandler({
+      url: URL,
+      clientName: "Test Client",
+      redirectUris: ["http://localhost/callback"],
+      cacheMaxAgeSeconds,
+    })
+  );
+  return app;
+};
+
+describe("clientMetadataHandler", () => {
+  it("serves the document as JSON with client_id matching the hosting URL", async () => {
+    const response = await request(buildApp()).get("/oauth/client-metadata.json");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toMatch(/application\/json/);
+    expect(response.body).toEqual({
+      client_id: URL,
+      client_name: "Test Client",
+      redirect_uris: ["http://localhost/callback"],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    });
+  });
+
+  it("sets a default Cache-Control header", async () => {
+    const response = await request(buildApp()).get("/oauth/client-metadata.json");
+    expect(response.headers["cache-control"]).toBe("public, max-age=3600");
+  });
+
+  it("honours a custom cache max-age", async () => {
+    const response = await request(buildApp(60)).get("/oauth/client-metadata.json");
+    expect(response.headers["cache-control"]).toBe("public, max-age=60");
+  });
+
+  it("fails fast at setup time on invalid configuration", () => {
+    expect(() =>
+      clientMetadataHandler({
+        url: "http://insecure.example.com/client.json",
+        clientName: "Test Client",
+        redirectUris: ["http://localhost/callback"],
+      })
+    ).toThrow(/https scheme/);
+  });
+});

--- a/library/src/clientMetadataHandler.ts
+++ b/library/src/clientMetadataHandler.ts
@@ -1,0 +1,40 @@
+import type { RequestHandler } from "express";
+import { buildClientMetadataDocument, type ClientMetadataDocumentOptions } from "./client/clientMetadataDocument.js";
+
+export interface ClientMetadataHandlerOptions extends ClientMetadataDocumentOptions {
+  /**
+   * Value for the Cache-Control max-age directive, in seconds.
+   * Authorization servers cache CIMD documents per HTTP caching semantics,
+   * so this controls how quickly metadata changes propagate. Defaults to 3600.
+   */
+  cacheMaxAgeSeconds?: number;
+}
+
+/**
+ * Express handler that serves an OAuth Client ID Metadata Document (CIMD).
+ *
+ * Mount this at the exact path of the configured `url` so the served
+ * document's client_id matches the URL authorization servers fetch:
+ *
+ * ```ts
+ * app.get(
+ *   "/oauth/client-metadata.json",
+ *   clientMetadataHandler({
+ *     url: "https://myagent.example.com/oauth/client-metadata.json",
+ *     clientName: "My Agent",
+ *     redirectUris: ["https://myagent.example.com/oauth/callback"],
+ *   })
+ * );
+ * ```
+ *
+ * The document is built (and validated) once at setup time, so configuration
+ * errors fail at startup rather than when an authorization server fetches it.
+ */
+export const clientMetadataHandler = (options: ClientMetadataHandlerOptions): RequestHandler => {
+  const document = buildClientMetadataDocument(options);
+  const maxAge = options.cacheMaxAgeSeconds ?? 3600;
+  return (_req, res) => {
+    res.setHeader("Cache-Control", `public, max-age=${maxAge}`);
+    res.json(document);
+  };
+};

--- a/library/src/index.ts
+++ b/library/src/index.ts
@@ -8,6 +8,7 @@ import type { CivicAuthOptions, ExtendedAuthInfo, OIDCWellKnownConfiguration } f
 import { AuthenticationError } from "./types.js";
 
 export * from "./client/index.js";
+export { type ClientMetadataHandlerOptions, clientMetadataHandler } from "./clientMetadataHandler.js";
 export * from "./constants.js";
 export { InMemoryStateStore } from "./legacy/StateStore.js";
 export type { OAuthState, StateStore } from "./legacy/types.js";


### PR DESCRIPTION
## Summary

Adds client-side support for [OAuth Client ID Metadata Documents](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00) (CIMD, [SEP-991](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/991)) — the preferred client registration mechanism in the MCP spec since 2025-11-25, used by Claude, Claude Code, and VS Code. Pairs with AUTH-316 (CIMD support in Civic Auth).

### Pass an already-hosted metadata URL

`CivicAuthProvider` (and therefore `CLIAuthProvider`) accepts `clientMetadataUrl` as an alternative to a pre-registered `clientId`. The MCP SDK uses the URL directly as the `client_id` when the authorization server advertises `client_id_metadata_document_supported`, and falls back to Dynamic Client Registration otherwise (now functional via the new `saveClientInformation` implementation). A pre-registered `clientId` always takes precedence, matching the spec's priority order.

### Build and host a metadata document

- `buildClientMetadataDocument()` (`@civic/auth-mcp/client`) builds a spec-compliant document; `client_id` is derived from the hosting URL so the exact-match rule can't be violated. `token_endpoint_auth_method` is fixed to `none` (CIMD clients are public + PKCE).
- `clientMetadataHandler()` (`@civic/auth-mcp`) serves the document via Express with configurable Cache-Control, validated once at startup.
- `LOOPBACK_REDIRECT_URIS` provides portless loopback redirect URIs for CLI/native clients per RFC 8252 (same shape Claude Code publishes).

## Test plan

- [x] 22 new unit tests (URL validation, document defaults, handler headers, provider precedence/save-restore)
- [x] Full suite: 181 tests, lint, typecheck, build all green
- [ ] End-to-end against Civic Auth once AUTH-316 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)